### PR TITLE
Don't filter on required mods list

### DIFF
--- a/app/store/mods-state/mod-categories-state.ts
+++ b/app/store/mods-state/mod-categories-state.ts
@@ -1,5 +1,6 @@
 import { selector } from 'recoil';
 
+import { modList } from './mods-state';
 import { filteredModList } from './mod-filter-state';
 import { requiredDependencyIdsState } from './mod-dependencies-state';
 import { modIsLoadingState } from './mod-progress-state';
@@ -45,7 +46,7 @@ export const notInstalledModList = selector({
 export const requiredModList = selector({
   key: 'RequiredMods',
   get: ({ get }) =>
-    get(nonAddonModList).filter(
+    get(modList).filter(
       (mod) =>
         (!mod.localVersion || !mod.isEnabled) &&
         !get(modIsLoadingState(mod.uniqueName)) &&


### PR DESCRIPTION
Sometimes a search a mod in the mod manager and I install/enable it and it shows the warning that there are required dependencies that need to be enabled. However, the required mods list is also filtered by my search and so I have to remove the search to be able to see the required mods, and I find this really annoying, so I think it would be better to no filter on the required mods list at all (I don't know if there is a use case where such filter would be desired).

Before:
![before](https://user-images.githubusercontent.com/22490080/189546022-92cbbaa2-3a4e-4dc9-ab77-024f9ac2c31d.gif)

After:
![after](https://user-images.githubusercontent.com/22490080/189546098-d9372925-34d2-4ef0-8d01-38a10d4306c9.gif)

Additionally, by doing this I found a bug. The START GAME button is only disabled if there are non-filtered required mods, so if we filter them then the button is enabled. So this change also fixes that bug.