### PR TITLE
fix #176: config.json from releases not being deleted

### DIFF
--- a/app/services/mods.ts
+++ b/app/services/mods.ts
@@ -74,17 +74,17 @@ async function install(mod: Mod, onProgress: ProgressHandler) {
     return;
   }
 
-  const [temporaryPath, unzipPath] = await unzipRemoteFile(
+  const [temporaryPath, unzipInnerPath] = await unzipRemoteFile(
     mod,
     mod.downloadUrl,
     onProgress
   );
 
   if (mod.localVersion) {
-    cleanup(mod, `${unzipPath}/manifest.json`);
+    cleanup(mod, `${unzipInnerPath}/manifest.json`);
   }
 
-  await copyFolder(unzipPath, mod.modPath);
+  await copyFolder(unzipInnerPath, mod.modPath);
   deleteFolder(temporaryPath);
 }
 
@@ -111,17 +111,17 @@ async function upstallPrerelease(mod: Mod, onProgress: ProgressHandler) {
     return;
   }
 
-  const [temporaryPath, unzipPath] = await unzipRemoteFile(
+  const [temporaryPath, unzipInnerPath] = await unzipRemoteFile(
     mod,
     mod.prerelease.downloadUrl,
     onProgress
   );
 
   if (mod.localVersion) {
-    cleanup(mod, `${unzipPath}/manifest.json`);
+    cleanup(mod, `${unzipInnerPath}/manifest.json`);
   }
 
-  await copyFolder(unzipPath, mod.modPath);
+  await copyFolder(unzipInnerPath, mod.modPath);
   deleteFolder(temporaryPath);
 }
 


### PR DESCRIPTION
If a release contains a `config.json`, this is only deleted if it is in the root zip path, so this doesn't work in the cases where the zip contains only a folder with the mod contents. To fix it, now the config file is searched in the zip "inner path". 
The same issue was when trying to read the `manifest.json` to use its `pathsToPreserve`  when updating a mod: it wouldn't find the manifest and it would [fallback](https://github.com/ow-mods/ow-mod-manager/blob/bc38c1de884dd9d190b85e881c31e7f1197b8dea/app/services/mods.ts#L47) to the `pathsToPreserve` of the installed local mod instead of the new version. This is especially important when a mod initial release doesn't include a `pathsToPreserve` but added it on a new version ([example](https://github.com/piggeywig2000/OuterWildsPermadeath/releases/tag/1.1.1)), the user would have its save data deleted after updating the mod. This is also fixed in this PR.

Example gifs since Rai likes them. ::D 
The example is the one described in #176, a The Vision release that had a `config.json`  with `"enabled": false`, when installing the mod the user had to manually enable it because of this.

Before:
![before](https://user-images.githubusercontent.com/22490080/189804464-42526278-9391-47d9-b767-9b2486e1dab2.gif)

After:
![after](https://user-images.githubusercontent.com/22490080/189804490-f23a1f02-58f2-480d-85f4-a9e0d32c0f98.gif)


